### PR TITLE
bottom pixel overflow removed

### DIFF
--- a/lib/onboarding.dart
+++ b/lib/onboarding.dart
@@ -9,149 +9,149 @@ class Onboarding extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: Container(
-          width: MediaQuery.of(context).size.width,
-          height: MediaQuery.of(context).size.height,
-          padding: EdgeInsets.only(
-            top: MediaQuery.of(context).padding.top,
-          ),
-          color: Colors.white,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            children: [
-              Container(
-                width: MediaQuery.of(context).size.width,
-                height: 146,
-                decoration: const BoxDecoration(color: Color(0xFFFF9F1C)),
-                child: const Column(
+        child: SingleChildScrollView( // Added SingleChildScrollView
+          child: Container(
+            width: MediaQuery.of(context).size.width,
+            padding: EdgeInsets.only(
+              top: MediaQuery.of(context).padding.top,
+            ),
+            color: Colors.white,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                Container(
+                  width: MediaQuery.of(context).size.width,
+                  height: 146,
+                  decoration: const BoxDecoration(color: Color(0xFFFF9F1C)),
+                  child: const Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        'SpoonShare',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 28,
+                          fontFamily: 'Lora',
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 1.12,
+                        ),
+                      ),
+                      SizedBox(height: 3),
+                      Text(
+                        'Nourishing Lives, Creating Smiles!',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 14,
+                          fontFamily: 'DM Sans',
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Container(
+                  width: 310,
+                  height: 290,
+                  padding: const EdgeInsets.only(
+                    left: 32,
+                    right: 32,
+                    top: 42,
+                  ),
+                  decoration: const BoxDecoration(
+                    image: DecorationImage(
+                      image: AssetImage("assets/images/onboarding.png"),
+                      fit: BoxFit.fill,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  'Be the Spoon in someone\'s road,',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontSize: 16,
+                    fontFamily: 'DM Sans',
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const Text(
+                  'feed hope instead of hunger.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontSize: 16,
+                    fontFamily: 'DM Sans',
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(height: 50),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).pushReplacement(MaterialPageRoute(
+                      builder: (context) => const SignUpScreen(),
+                    ));
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFF9F1C),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(50),
+                    ),
+                  ),
+                  child: const Text(
+                    'START DONATING',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontFamily: 'DM Sans',
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 18),
+                Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Text(
-                      'SpoonShare',
+                      'Already a member?',
                       style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 28,
-                        fontFamily: 'Lora',
-                        fontWeight: FontWeight.w700,
-                        letterSpacing: 1.12,
-                      ),
-                    ),
-                    SizedBox(height: 3),
-                    Text(
-                      'Nourishing Lives, Creating Smiles!',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 14,
+                        color: Colors.black.withOpacity(0.6),
+                        fontSize: 13,
                         fontFamily: 'DM Sans',
                         fontWeight: FontWeight.w500,
                       ),
                     ),
+                    const SizedBox(height: 8),
+                    OutlinedButton(
+                      onPressed: () {
+                        Navigator.of(context).pushReplacement(MaterialPageRoute(
+                          builder: (context) => const SignInScreen(),
+                        ));
+                      },
+                      style: OutlinedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 32, vertical: 12),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(50),
+                        ),
+                      ),
+                      child: const Text(
+                        'LOGIN',
+                        style: TextStyle(
+                          color: Colors.black,
+                          fontSize: 16,
+                          fontFamily: 'DM Sans',
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
                   ],
                 ),
-              ),
-              Container(
-                width: 310,
-                height: 290,
-                padding: const EdgeInsets.only(
-                  left: 32,
-                  right: 32,
-                  top: 42,
-                ),
-                decoration: const BoxDecoration(
-                  image: DecorationImage(
-                    image: AssetImage("assets/images/onboarding.png"),
-                    fit: BoxFit.fill,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              const Text(
-                'Be the Spoon in someone\'s road,',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: Colors.black,
-                  fontSize: 16,
-                  fontFamily: 'DM Sans',
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              const Text(
-                'feed hope instead of hunger.',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: Colors.black,
-                  fontSize: 16,
-                  fontFamily: 'DM Sans',
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              const SizedBox(height: 50),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).pushReplacement(MaterialPageRoute(
-                    builder: (context) => const SignUpScreen(),
-                  ));
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFFFF9F1C),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(50),
-                  ),
-                ),
-                child: const Text(
-                  'START DONATING',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontFamily: 'DM Sans',
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 18),
-              Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    'Already a member?',
-                    style: TextStyle(
-                      color: Colors.black.withOpacity(0.6),
-                      fontSize: 13,
-                      fontFamily: 'DM Sans',
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  OutlinedButton(
-                    onPressed: () {
-                      Navigator.of(context).pushReplacement(MaterialPageRoute(
-                        builder: (context) => const SignInScreen(),
-                      ));
-                    },
-                    style: OutlinedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 32, vertical: 12),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(50),
-                      ),
-                    ),
-                    child: const Text(
-                      'LOGIN',
-                      style: TextStyle(
-                        color: Colors.black,
-                        fontSize: 16,
-                        fontFamily: 'DM Sans',
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 50),
-                   Container(
-                  margin:
+                const SizedBox(height: 50),
+                Container(
+                  margin: 
                       const EdgeInsets.only(bottom: 40), // Add margin to the top
                   child: SizedBox(
                     width: 296,
@@ -207,7 +207,8 @@ class Onboarding extends StatelessWidget {
                     ),
                   ),
                 ),
-        ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/auth/signup.dart
+++ b/lib/screens/auth/signup.dart
@@ -50,7 +50,6 @@ class _SignUpScreenState extends State<SignUpScreen> {
         child: Center(
           child: Container(
             width: MediaQuery.of(context).size.width,
-            height: MediaQuery.of(context).size.height + 40,
             padding: EdgeInsets.only(
               top: MediaQuery.of(context).padding.top,
             ),


### PR DESCRIPTION
Fixes issue #6 
I have fixed the UI bottom pixel overflow on the signup and splash screens.
Made changes in the following two files:
In signup.dart, the height of the widget was exceeded, resulting in a bottom pixel overflow error. Hence, I removed the height property set in the widget.
In onboarding.dart, I wrapped the Column widget with a SingleChildScrollView and removed the height property, making it scrollable.

Here are the changed screenshots of the same:
![WhatsApp Image 2024-05-21 at 10 41 30_a5072096](https://github.com/sanika391/SpoonShare/assets/124724639/936231a2-eb31-468b-bc29-2aea8e96f40e)

![WhatsApp Image 2024-05-21 at 10 41 31_1d456762](https://github.com/sanika391/SpoonShare/assets/124724639/b221cd4d-76e6-44fd-9a57-b5cc6b820b9c)