### PR TITLE
Fix Back Button Behavior on Recycle Request Page : issue #68

### DIFF
--- a/lib/screens/recycle/recycle.dart
+++ b/lib/screens/recycle/recycle.dart
@@ -161,7 +161,7 @@ class RecycleScreen extends StatelessWidget {
                       const SizedBox(height: 50),
                       GestureDetector(
                         onTap: () {
-                          Navigator.pushReplacement(
+                          Navigator.push(
                             context,
                             MaterialPageRoute(
                               builder: (BuildContext context) =>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.33"
+  adaptive_theme:
+    dependency: "direct main"
+    description:
+      name: adaptive_theme
+      sha256: f4ee609b464e5efc68131d9d15ba9aa1de4e3b5ede64be17781c6e19a52d637d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.0"
   archive:
     dependency: transitive
     description:


### PR DESCRIPTION
**Description:**

This pull request addresses the issue with the back button functionality on the Recycle Request page in the SpoonShare app. The issue caused the page to become blank when the back button was clicked. The changes implemented ensure proper navigation and usability.

**Changes Made:**

Implemented a fix for the back button behavior on the Recycle Request page.
Ensured that clicking the back button in the app bar navigates back to the previous page without causing a blank screen.

**Testing:**

Verified that the back button now functions correctly on the Recycle Request page.
Tested the navigation flow to ensure a smooth user experience.

**Video**

https://github.com/sanika391/SpoonShare/assets/123234840/9161a9ab-b46b-41ac-9466-63d2fe150b1a


Please review the changes and provide feedback if any adjustments are needed.

Thank our for your assistance mam.