### PR TITLE
Back Button on Recycle Request Page Causes Blank Screen #68

### DIFF
--- a/lib/screens/recycle/pickup_food.dart
+++ b/lib/screens/recycle/pickup_food.dart
@@ -498,7 +498,7 @@ class _RecycleFoodScreenContentState extends State<RecycleFoodScreenContent> {
           .collection("foodData")
           .add(foodData);
 
-      Navigator.of(context).pop();
+      //Navigator.of(context).pop();
       showSuccessSnackbar(context, 'Food submitted successfully!');
       Navigator.push(context,
           MaterialPageRoute(builder: (context) => const ThankYouScreen()));

--- a/lib/screens/recycle/recycle.dart
+++ b/lib/screens/recycle/recycle.dart
@@ -161,7 +161,7 @@ class RecycleScreen extends StatelessWidget {
                       const SizedBox(height: 50),
                       GestureDetector(
                         onTap: () {
-                          Navigator.pushReplacement(
+                          Navigator.push(
                             context,
                             MaterialPageRoute(
                               builder: (BuildContext context) =>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.33"
+  adaptive_theme:
+    dependency: "direct main"
+    description:
+      name: adaptive_theme
+      sha256: f4ee609b464e5efc68131d9d15ba9aa1de4e3b5ede64be17781c6e19a52d637d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.0"
   archive:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixed back button working on navigation bar on Recycle Request Page:

Details of changes:-
On the Request Pickup Button instead of simply Navigator.Push( )code contains Navigator.Pushreplacement( ) which is causing the removal of previous screen in stack resulting in white screen..

@sanika391  I have also suggested some changes in color theme of navigation bar on same screen do also consider it..